### PR TITLE
Add stdlib.system

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ func init() {
             stdarg.h	       4/4	         100%
             stddef.h	       2/6	        33.3%
              stdio.h	     33/46	        71.7%
-            stdlib.h	     31/47	          66%
+            stdlib.h	     32/47	        68.1%
             string.h	     11/24	        45.8%
               time.h	      8/15	        53.3%
              wchar.h	      0/68	           0%

--- a/noarch/stdlib.go
+++ b/noarch/stdlib.go
@@ -1,8 +1,11 @@
 package noarch
 
 import (
+	"io"
 	"math"
 	"os"
+	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -347,6 +350,53 @@ func Strtoull(str []byte, endptr [][]byte, radix int) uint64 {
 	return uint64(Strtoll(str, endptr, radix))
 }
 
+// System executes the given external command with parameters. Unlike system(3)
+// in C, System (and the underlying golang exec) do not invoke the system
+// command processor.
+func System(str []byte) int {
+	input := string(str)
+	if input[len(input)-1] == '\x00' {
+		input = input[:len(input)-1]
+	}
+	re := regexp.MustCompile(`[^\s"']+|([^\s"']*"([^"]*)"[^\s"']*)+|'([^']*)`)
+	args := re.FindAllString(input, -1)
+	cmd := exec.Command(args[0], args[1:]...)
+	var stdout, stderr []byte
+	var errStdout, errStderr error
+
+	// These are unused in integration tests, so silence "declared but unused"
+	// errors during integration testing.
+	_ = stdout
+	_ = stderr
+	_ = errStdout
+	_ = errStderr
+
+	stdoutIn, _ := cmd.StdoutPipe()
+	stderrIn, _ := cmd.StderrPipe()
+	cmd.Start()
+
+	go func() {
+		stdout, errStdout = capture(os.Stdout, stdoutIn)
+	}()
+
+	go func() {
+		stderr, errStderr = capture(os.Stderr, stderrIn)
+	}()
+
+	err := cmd.Wait()
+
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "exit status ") {
+			result, _ := strconv.Atoi(strings.Split(err.Error(), " ")[2])
+			return result
+		} else {
+			return 1
+		}
+	} else {
+		return 0
+	}
+}
+
 // Free doesn't do anything since memory is managed by the Go garbage collector.
 // However, I will leave it here as a placeholder for now.
 func Free(anything interface{}) {
@@ -421,4 +471,33 @@ func atof(str []byte) (float64, int) {
 	}
 
 	return 0, 0
+}
+
+// The capture function is used by noarch.System to imitate
+// the behavior of C's system(3) instead of golang's exec by
+// grabbing command output as it is generated and displays
+// it rather than displaying it after execution completes.
+func capture(w io.Writer, r io.Reader) ([]byte, error) {
+	var out []byte
+	buf := make([]byte, 1024, 1024)
+	for {
+		n, err := r.Read(buf[:])
+		if n > 0 {
+			d := buf[:n]
+			out = append(out, d...)
+			_, err := w.Write(d)
+			if err != nil {
+				return out, err
+			}
+		}
+		if err != nil {
+			// io.EOF is not actually an error
+			if err == io.EOF {
+				err = nil
+			}
+			return out, err
+		}
+	}
+	panic(true)
+	return nil, nil
 }

--- a/program/function_definition.go
+++ b/program/function_definition.go
@@ -272,6 +272,7 @@ var builtInFunctionDefinitions = map[string][]string{
 		"long long strtoll(const char *, char **, int) -> noarch.Strtoll",
 		"long unsigned int strtoul(const char *, char **, int) -> noarch.Strtoul",
 		"long long unsigned int strtoull(const char *, char **, int) -> noarch.Strtoull",
+		"int system(const char *) -> noarch.System",
 		"void free(void*) -> _",
 	},
 	"time.h": {

--- a/tests/stdlib.c
+++ b/tests/stdlib.c
@@ -201,6 +201,12 @@ int compare(const void* a, const void* b)
     return (*(int*)a - *(int*)b);
 }
 
+void test_system() {
+    diag("system");
+    is_eq(system("true"), 0);
+    is_not_eq(system("false"), 0);
+}
+
 void q_sort()
 {
     diag("qsort");
@@ -226,7 +232,7 @@ void struct_with_define()
 
 int main()
 {
-    plan(753);
+    plan(755);
 
 	struct_with_define();
 
@@ -494,6 +500,8 @@ int main()
     test_strtol("123", 8, 83, "");
     test_strtol("123abc", 16, 1194684, "");
     test_strtol("123abc", 8, 83, "abc");
+
+    test_system();
 
     q_sort();
 


### PR DESCRIPTION
Implements the [`system`](https://en.cppreference.com/w/c/program/system) function. Unlike the C function, this relies on golang's `exec`, which does not call the system processor (it can only execute binaries; shell scripts have to be invoked as `sh myScript.sh`, etc.).