### PR TITLE
Add math.Hypot

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ func init() {
             iso646.h	          	    undefined
             limits.h	          	    undefined
             locale.h	       0/3	           0%
-              math.h	     36/58	        62.1%
+              math.h	     37/58	        63.8%
             setjmp.h	       0/3	           0%
             signal.h	       0/3	           0%
             stdarg.h	       4/4	         100%

--- a/noarch/math.go
+++ b/noarch/math.go
@@ -118,6 +118,11 @@ func Cbrtf(x float32) float32 {
 	return float32(math.Cbrt(float64(x)))
 }
 
+// Hypotf compute the square root of the sum of the squares of x and y
+func Hypotf(x, y float32) float32 {
+	return float32(math.Hypot(float64(x), float64(y)))
+}
+
 // Log1pf compute ln(1+arg)
 func Log1pf(arg float32) float32 {
 	return float32(math.Log1p(float64(arg)))

--- a/program/function_definition.go
+++ b/program/function_definition.go
@@ -178,6 +178,10 @@ var builtInFunctionDefinitions = map[string][]string{
 		"double cbrt(double) -> math.Cbrt",
 		"float cbrtf(float) -> noarch.Cbrtf",
 		"long double cbrtl(long double) -> math.Cbrt",
+
+		"double hypot(double, double) -> math.Hypot",
+		"float hypotf(float) -> noarch.Hypotf",
+		"long double hypotl(long double, long double) -> math.Hypot",
 	},
 	"stdio.h": {
 

--- a/tests/math.c
+++ b/tests/math.c
@@ -12,7 +12,7 @@ unsigned long long ullmax = 18446744073709551615ull;
 
 int main()
 {
-    plan(415);
+    plan(421);
 
 	double w1 = 100;
 	double w2 = 2;
@@ -678,6 +678,14 @@ int main()
         long double res = 2.12345;
         is_eq(cbrtl(res * res * res), res);
     }
+
+    diag("hypot, hypotf, hypotl");
+    is_eq(hypot(0, 0), 0);
+    is_eq(hypot(3, 4), 5);
+    is_eq(hypotf(0, 0), 0);
+    is_eq(hypotf(3, 4), 5);
+    is_eq(hypotl(0, 0), 0);
+    is_eq(hypotl(3, 4), 5);
 
     done_testing();
 }


### PR DESCRIPTION
Adds the [`hypot`, `hypotf`, and `hypotl`](https://en.cppreference.com/w/c/numeric/math/hypot) functions from `math.h`.