### PR TITLE
Add math.Remainder

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ func init() {
             iso646.h	          	    undefined
             limits.h	          	    undefined
             locale.h	       0/3	           0%
-              math.h	     37/58	        63.8%
+              math.h	     38/58	        65.5%
             setjmp.h	       0/3	           0%
             signal.h	       0/3	           0%
             stdarg.h	       4/4	         100%

--- a/program/function_definition.go
+++ b/program/function_definition.go
@@ -101,6 +101,7 @@ var builtInFunctionDefinitions = map[string][]string{
 		"double fabs(double) -> math.Abs",
 		"double floor(double) -> math.Floor",
 		"double fmod(double, double) -> math.Mod",
+		"double remainder(double, double) -> math.Remainder",
 		"double ldexp(double, int) -> math.Ldexp",
 		"double log(double) -> math.Log",
 		"double log10(double) -> math.Log10",

--- a/tests/math.c
+++ b/tests/math.c
@@ -12,7 +12,7 @@ unsigned long long ullmax = 18446744073709551615ull;
 
 int main()
 {
-    plan(421);
+    plan(476);
 
 	double w1 = 100;
 	double w2 = 2;
@@ -321,6 +321,73 @@ int main()
     is_nan(fmod(INFINITY, NAN));
     is_nan(fmod(-INFINITY, NAN));
     is_nan(fmod(NAN, NAN));
+
+    diag("remainder")
+
+    // remainder(x, 0)
+    is_nan(remainder(0, 0));
+    is_nan(remainder(1, 0));
+    is_nan(remainder(-1, 0));
+    is_nan(remainder(0.5, 0));
+    is_nan(remainder(1.23e300, 0));
+    is_nan(remainder(-1.23e-300, 0));
+    is_nan(remainder(M_PI, 0));
+    is_nan(remainder(M_E, 0));
+    is_nan(remainder(INFINITY, 0));
+    is_nan(remainder(-INFINITY, 0));
+    is_nan(remainder(NAN, 0));
+
+    // remainder(x, 0.5)
+    is_eq(remainder(0, 0.5), 0);
+    is_eq(remainder(1, 0.5), 0);
+    is_negzero(remainder(-1, 0.5));
+    is_eq(remainder(0.5, 0.5), 0);
+    is_eq(remainder(1.23e300, 0.5), 0);
+    is_negzero(remainder(-1.23e-300, 0.5));
+    is_eq(remainder(M_PI, 0.5), M_PI - 3);
+    is_eq(remainder(M_E, 0.5), M_E - 2.5);
+    is_nan(remainder(INFINITY, 0.5));
+    is_nan(remainder(-INFINITY, 0.5));
+    is_nan(remainder(NAN, 0.5));
+
+    // remainder(x, INFINITY)
+    is_eq(remainder(0, INFINITY), 0);
+    is_eq(remainder(1, INFINITY), 1);
+    is_negzero(remainder(-1, INFINITY));
+    is_eq(remainder(0.5, INFINITY), 0.5);
+    is_eq(remainder(1.23e300, INFINITY), 1.23e300);
+    is_negzero(remainder(-1.23e-300, INFINITY));
+    is_eq(remainder(M_PI, INFINITY), M_PI);
+    is_eq(remainder(M_E, INFINITY), M_E);
+    is_nan(remainder(INFINITY, INFINITY));
+    is_nan(remainder(-INFINITY, INFINITY));
+    is_nan(remainder(NAN, INFINITY));
+
+    // remainder(x, -INFINITY)
+    is_eq(remainder(0, -INFINITY), 0);
+    is_eq(remainder(1, -INFINITY), 1);
+    is_negzero(remainder(-1, -INFINITY));
+    is_eq(remainder(0.5, -INFINITY), 0.5);
+    is_eq(remainder(1.23e300, -INFINITY), 1.23e300);
+    is_negzero(remainder(-1.23e-300, -INFINITY));
+    is_eq(remainder(M_PI, -INFINITY), M_PI);
+    is_eq(remainder(M_E, -INFINITY), M_E);
+    is_nan(remainder(INFINITY, -INFINITY));
+    is_nan(remainder(-INFINITY, -INFINITY));
+    is_nan(remainder(NAN, -INFINITY));
+
+    // remainder(x, NAN)
+    is_nan(remainder(0, NAN));
+    is_nan(remainder(1, NAN));
+    is_nan(remainder(-1, NAN));
+    is_nan(remainder(0.5, NAN));
+    is_nan(remainder(1.23e300, NAN));
+    is_nan(remainder(-1.23e-300, NAN));
+    is_nan(remainder(M_PI, NAN));
+    is_nan(remainder(M_E, NAN));
+    is_nan(remainder(INFINITY, NAN));
+    is_nan(remainder(-INFINITY, NAN));
+    is_nan(remainder(NAN, NAN));
 
     diag("ldexp");
     is_eq(ldexp(0, 2), 0);


### PR DESCRIPTION
Adds [`remainder`](https://en.cppreference.com/w/c/numeric/math/remainder). This PR does not add `remainderf` or `remainderl`, but this is a starting point.